### PR TITLE
Chore: clean up the dates in the posts

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,5 +7,6 @@ future: true
 github: "compilerla/data-donuts"
 permalink: /event/:title.html
 source: ./src
+timezone: America/Los_Angeles
 url: "https://datadonuts.la"
 youtube: "youtube.com/channel/UC_mAa07EdkkGCn48lq0yj3Q"

--- a/src/_posts/2017-02-02-data-donuts-01.md
+++ b/src/_posts/2017-02-02-data-donuts-01.md
@@ -2,8 +2,8 @@
 layout: post
 
 #event information
-title:  "Data + Donuts @ LACI"
-date:   2017-02-02 08:00+0800
+title: "Data + Donuts @ LACI"
+date: 2017-02-02 08:00
 start_time: "8:00am"
 end_time: "10:00am"
 
@@ -18,4 +18,5 @@ video: ""
 ---
 
 #### About Ted Ross
+
 Ted Ross is CIO for the City of Los Angeles and General Manager for the Information Technology Agency (ITA). His department delivers enterprise IT services to over 48,000 employees across 38 City departments and digital services to almost 4 million residents across 469 square miles. Comprised of 455 dedicated employees with a $90 million annual operating budget, his department supports more than 125 City applications, a 24/7 Data Center, City Data & Voice Communications, the 3-1-1 Call Center, Public Safety Microwave & Radio Communications, and the LA CityView Channel 35 TV Station. Ted has over 21 years of private and public sector technology experience, earning various awards and IT credentials along the way.

--- a/src/_posts/2017-03-15-data-donuts-02.md
+++ b/src/_posts/2017-03-15-data-donuts-02.md
@@ -2,8 +2,8 @@
 layout: post
 
 #event information
-title:  "Data + Donuts @ LACI"
-date:   2017-03-15 08:00+0800
+title: "Data + Donuts @ LACI"
+date: 2017-03-15 08:00
 start_time: "8:00am"
 end_time: "10:00am"
 
@@ -18,4 +18,5 @@ video: ""
 ---
 
 #### About Jeramy Gray
-With over 20 years of Information Technology (IT) experience, Jeramy Gray has served as Chief Information Officer for three Los Angeles County agencies.  On February 14th, 2017 Jeramy was appointed by the Executive Office of the Board of Supervisors as Assistant Executive Officer of Technology and Planning.  In this position Jeramy oversees technology services and project planning for the County’s five elected Board Offices, County Commissions, Advisory Bodies and various administrative operations within the Executive Office.  Additionally, Jeramy is responsible for advising the Board on Countywide information technology standards, policy, and processes.  Prior to his role within the Executive Office of the Board, Jeramy was the Assistant Registrar-Recorder County Clerk, of Information Technology. His responsibilities included oversight of all  IT services,  strategic planning, governance, and fiscal management; in addition his responsibilities included oversight of LA County’s voting system redesign project.   On February 5, 2016 Jeramy was jointly appointed by the United States Elections Assistance Commission (EAC) and National Institute of Standards and Technology (NIST) to be a member of the Technical Development Guidelines Committee. As a member of this committee, Jeramy assisted in the development of national standards for voting technology. 
+
+With over 20 years of Information Technology (IT) experience, Jeramy Gray has served as Chief Information Officer for three Los Angeles County agencies. On February 14th, 2017 Jeramy was appointed by the Executive Office of the Board of Supervisors as Assistant Executive Officer of Technology and Planning. In this position Jeramy oversees technology services and project planning for the County’s five elected Board Offices, County Commissions, Advisory Bodies and various administrative operations within the Executive Office. Additionally, Jeramy is responsible for advising the Board on Countywide information technology standards, policy, and processes. Prior to his role within the Executive Office of the Board, Jeramy was the Assistant Registrar-Recorder County Clerk, of Information Technology. His responsibilities included oversight of all IT services, strategic planning, governance, and fiscal management; in addition his responsibilities included oversight of LA County’s voting system redesign project. On February 5, 2016 Jeramy was jointly appointed by the United States Elections Assistance Commission (EAC) and National Institute of Standards and Technology (NIST) to be a member of the Technical Development Guidelines Committee. As a member of this committee, Jeramy assisted in the development of national standards for voting technology.

--- a/src/_posts/2017-04-19-data-donuts-03.md
+++ b/src/_posts/2017-04-19-data-donuts-03.md
@@ -2,8 +2,8 @@
 layout: post
 
 #event information
-title:  "Data + Donuts @ General Assembly (DTLA)"
-date:   2017-04-19 08:00+0800
+title: "Data + Donuts @ General Assembly (DTLA)"
+date: 2017-04-19 08:00
 start_time: "8:00am"
 end_time: "10:00am"
 
@@ -18,13 +18,14 @@ video: ""
 ---
 
 # Speaker
-__Umi Hsu__<br>
+
+**Umi Hsu**<br>
 _Digital Strategist/Senior Project Coordinator, City of Los Angeles Department of Cultural Affairs_
 
 {% include icon-twitter.html username="wfumihsu" %}
 
 Umi Hsu is a researcher, strategist, and educator who engages with hybrid research and organizing agendas for equality in arts, technology, and civic participation. A former ACLS Public Fellow, Hsu currently works as the digital strategist of the City of Los Angeles Department of Cultural Affairs, providing research and strategy to redesign the department’s data and knowledge architecture. They are also the founder of Lab at DCA, a city staff innovation incubator. Hsu has served on the advisory committee for Arts for LA, Center for Cultural Innovation, California Community Foundation’s Social Change Data Commons, Cultural Research Network, and the Society of Ethnomusicology Council. They also lead two community-driven arts collectives LA Listens and Movable Parts. Since 2007, Hsu has taught at University of Virginia, Occidental College, and Art Center College of Design.
 
-__From Local Knowledge to Collective Intelligence:__
+**From Local Knowledge to Collective Intelligence:**
 
 "What is the value of local knowledge in the age of (big) data? Local knowledge in government work consists of institutional knowledge, informal networks, individual propensities, organizational and community culture. These can be assets to innovation projects. Drawing on my work developing digital literacy and research capacity at DCA, I will illustrate a human-centric knowledge architecture for government agencies and discuss how we can extend the impulse to learn, curiosities about impact, and lines of inquiries from staff, residents and communities."

--- a/src/_posts/2017-05-25-data-donuts-04.md
+++ b/src/_posts/2017-05-25-data-donuts-04.md
@@ -2,8 +2,8 @@
 layout: post
 
 #event information
-title:  "Data + Donuts @ California Community Foundation"
-date:   2017-05-25 08:00+0800
+title: "Data + Donuts @ California Community Foundation"
+date: 2017-05-25 08:00
 start_time: "8:00am"
 end_time: "10:00am"
 
@@ -15,11 +15,11 @@ speakers:
 eventbrite: "//eventbrite.com/tickets-external?eid=33376931300&ref=etckt"
 slides: ""
 video: ""
-
 ---
 
 # Speaker
-__Voting Systems Assessment Project Team__<br>
+
+**Voting Systems Assessment Project Team**<br>
 _Registrar-Recorder/County Clerk_
 
 The Voting Systems Assessment Project is Los Angeles County’s effort to design, develop and implement a modernized voting experience. This innovative project will produce a certified voting system that is publicly owned. The project has taken a data-driven approach and utilized human centered design principles to ensure that the unique needs of our voters are met. During this presentation we will provide an update on the progress of the project as well as a discussion of how data and human centered design principles work together.

--- a/src/_posts/2017-06-21-data-donuts-05.md
+++ b/src/_posts/2017-06-21-data-donuts-05.md
@@ -2,8 +2,8 @@
 layout: post
 
 #event information
-title:  "Data + Donuts @ LACI"
-date:   2017-06-21 08:00+0800
+title: "Data + Donuts @ LACI"
+date: 2017-06-21 08:00
 start_time: "8:00am"
 end_time: "10:00am"
 
@@ -18,8 +18,8 @@ video: ""
 ---
 
 #### About Matt Petersen
+
 Matt Petersen was named Chief Sustainability officer by Mayor Eric Garcetti of Los Angeles. As the first ever CSO for the City of LA, Matt is focused on helping Mayor Garcetti create 20,000 green jobs in LA, create a more sustainable and livable city and neighborhoods, and hold every city department responsible for cleaner air and water.
 <br>
 
 Before joining the Mayor’s office, Matt served as President and CEO of Global Green USA for 19 years. Passionate about improving the lives of those in need, combatting climate change and greening communities, Petersen focused the organization on greening affordable housing, schools and cities (including LA). Petersen led the organization in the green rebuilding of New Orleans after Hurricane Katrina, and later to communities devastated by Hurricane Sandy. Matt is a board member of Global Green USA and Habitat for Humanity of Greater Los Angeles, as well as is a member of the Council on Foreign Relations and an advisor to the Clinton Global Initiative.
-

--- a/src/_posts/2017-08-23-data-donuts-06.md
+++ b/src/_posts/2017-08-23-data-donuts-06.md
@@ -2,8 +2,8 @@
 layout: post
 
 #event information
-title:  "Data + Donuts @ LACI"
-date:   2017-08-23 08:00+0800
+title: "Data + Donuts @ LACI"
+date: 2017-08-23 08:00
 start_time: "8:00am"
 end_time: "10:00am"
 
@@ -19,4 +19,4 @@ video: ""
 
 <!-- Speaker Bio -->
 
-Helen is an urban planner and spatial analyst focused on the intersection of affordable housing, sustainability and city planning.  She has worked in both the government and non-profit sectors for over a decade and is currently a City Planning Associate for the City of Los Angeles Department of City Planning. Previously, Helen served as a Housing Planning and Economic Analyst for the City’s Housing + Community Investment Department for six years, where she spearheaded several GIS and data driven initiatives. She develops maps to illustrate and simplify planning concepts to lay persons, create transparency and promote collaborative/evidence based decision making. Helen is a board member of the Beverly Vermont Community Land Trust and an advisory board member of the LA Planning and Land Use Society.
+Helen is an urban planner and spatial analyst focused on the intersection of affordable housing, sustainability and city planning. She has worked in both the government and non-profit sectors for over a decade and is currently a City Planning Associate for the City of Los Angeles Department of City Planning. Previously, Helen served as a Housing Planning and Economic Analyst for the City’s Housing + Community Investment Department for six years, where she spearheaded several GIS and data driven initiatives. She develops maps to illustrate and simplify planning concepts to lay persons, create transparency and promote collaborative/evidence based decision making. Helen is a board member of the Beverly Vermont Community Land Trust and an advisory board member of the LA Planning and Land Use Society.

--- a/src/_posts/2017-09-20-data-donuts-07.md
+++ b/src/_posts/2017-09-20-data-donuts-07.md
@@ -2,8 +2,8 @@
 layout: post
 
 #event information
-title:  "Data + Donuts @ LACI"
-date:   2017-09-20 08:00+0800
+title: "Data + Donuts @ LACI"
+date: 2017-09-20 08:00
 start_time: "8:00am"
 end_time: "10:00am"
 
@@ -16,4 +16,3 @@ eventbrite: "//eventbrite.com/tickets-external?eid=37863201856&ref=etckt"
 slides: ""
 video: ""
 ---
-

--- a/src/_posts/2017-10-24-data-donuts-08.md
+++ b/src/_posts/2017-10-24-data-donuts-08.md
@@ -2,8 +2,8 @@
 layout: post
 
 #event information
-title:  "Data + Donuts @ LACI"
-date:   2017-10-24 08:00+0800
+title: "Data + Donuts @ LACI"
+date: 2017-10-24 08:00
 start_time: "8:00am"
 end_time: "10:00am"
 
@@ -17,4 +17,4 @@ slides: "//docs.google.com/presentation/d/e/2PACX-1vQUcLLKvYECk101E9dalFtMjg7t-3
 video: ""
 ---
 
-Since 2016, as the County’s Chief Data Officer, Mark’s goal is to facilitate countywide information sharing and management, support data driven decision making, and provide a 360 degree view of county residents.  This will help ensure the County provides the right service at the right time to ensure the best outcomes for its residents.  
+Since 2016, as the County’s Chief Data Officer, Mark’s goal is to facilitate countywide information sharing and management, support data driven decision making, and provide a 360 degree view of county residents. This will help ensure the County provides the right service at the right time to ensure the best outcomes for its residents.

--- a/src/_posts/2018-01-10-data-donuts-09.md
+++ b/src/_posts/2018-01-10-data-donuts-09.md
@@ -2,8 +2,8 @@
 layout: post
 
 #event information
-title:  "Data + Donuts @ LACI"
-date:   2018-01-10 08:00+0800
+title: "Data + Donuts @ LACI"
+date: 2018-01-10 08:00
 start_time: "8:00am"
 end_time: "10:00am"
 
@@ -19,6 +19,6 @@ video: "www.youtube.com/embed/ZUPt3YXXJ2I"
 
 #### About George Khalil
 
-George holds a Master’s degree in Information Security Engineering from the SANS Technology Institute. His professional experience spans over 20 years managing networks, servers, storage and security infrastructure. George has been leading enterprise security architecture, compliance, auditing and policy development for government agencies, critical infrastructure, and law enforcement sectors. Before public service, He also worked for several Fortune 500’s, and Fortune 1000’s such as EarthLink Networks, SeeBeyond Technologies, and Sun Microsystems. Under George’s leadership, The City of Riverside’s won the 2017 program excellence award by the International City  / County management association for its next generation municipal cyber security program.
+George holds a Master’s degree in Information Security Engineering from the SANS Technology Institute. His professional experience spans over 20 years managing networks, servers, storage and security infrastructure. George has been leading enterprise security architecture, compliance, auditing and policy development for government agencies, critical infrastructure, and law enforcement sectors. Before public service, He also worked for several Fortune 500’s, and Fortune 1000’s such as EarthLink Networks, SeeBeyond Technologies, and Sun Microsystems. Under George’s leadership, The City of Riverside’s won the 2017 program excellence award by the International City / County management association for its next generation municipal cyber security program.
 <br><br>
 In addition to his experience, George is also a certified intrusion analyst, incident handler, network, and systems auditor, Forensic Analyst, Penetration Tester, Project Manager and Certified Security Expert. George has completed PCI DSS Auditing, Security awareness program management, and Staff development through reflective coaching. He also published several peer-reviewed papers on the topics of iOS messaging security, secure network engineering for next-generation data centers, password security, project management, High throughput Intrusion Analysis and Forensic network design. George’s data loss prevention article was featured on the cover of the July 2017 edition of western cities magazine and republished by PublicCEO.com. George presented at SANS Network Security Conferences, Southern California Mayor’s conference, City Clerk’s Association of California, Inland Empire security summit, Cyber Security for Critical Infrastructure, Riverside chamber of commerce and is a member of the GIAC Advisory Board.

--- a/src/_posts/2018-02-13-data-donuts-10.md
+++ b/src/_posts/2018-02-13-data-donuts-10.md
@@ -2,8 +2,8 @@
 layout: post
 
 #event information
-title:  "Data + Donuts @ LACI"
-date:   2018-02-13 08:00+0800
+title: "Data + Donuts @ LACI"
+date: 2018-02-13 08:00
 start_time: "8:00am"
 end_time: "10:00am"
 

--- a/src/_posts/2018-03-13-data-donuts-11.md
+++ b/src/_posts/2018-03-13-data-donuts-11.md
@@ -2,8 +2,8 @@
 layout: post
 
 #event information
-title:  "Data + Donuts @ LACI"
-date:   2018-03-13 08:00+0800
+title: "Data + Donuts @ LACI"
+date: 2018-03-13 08:00
 start_time: "8:00am"
 end_time: "10:00am"
 
@@ -21,7 +21,9 @@ video: ""
 Join us this month to talk with Karina Macias, and Jeanne Holm about the [City of LA's Data Science Federation](http://dsf.lacity.org/) and how data science partnerships with local universities are changing the way the city staff thinks about data. The Data Science Federation is a City of Los Angeles led initiative with 14 local partner Universities, working with over 200 students and 100 professors and staff over the last two years.
 
 #### About Karina Macias
+
 Karina Macias is a transportation planner with the Los Angeles Department of Transportation. She uses data-driven analysis methods and research to effectuate strategic transportation planning initiatives and develop sustainable transportation policies in the City. She built and tested the Department’s first project scoring model to help support decisions around mobility investments and is currently collaborating with the City’s Information Technology Agency Data Science Federation and a team of California State University Los Angeles students to develop a parameterized model to automate mobility project scoring and estimate their benefits.
 
 #### About Jeanne Holm
+
 As a leader in open data, education, community-building, and civic innovation, Jeanne Holm empowers people to discover new knowledge and collaborate to improve life on Earth and beyond. Jeanne is the Deputy CIO and Senior Technology Advisor to the Mayor for the City of Los Angeles, bringing technical innovations to 4 million people. Her work in Los Angeles focuses on delivering great city services like 311, public television, and social media, and public-private collaborations for technology innovations ranging from data science to broadband. She was formerly the Evangelist for [open data](https://data.gov) for the White House, the leader for African open data for the World Bank, and the Chief Knowledge Architect at NASA. She is a Distinguished Instructor at [UCLA](http://dev.1000lessons.com/lessons/31/sharing-knowledge-catalyst-change), a Fellow of the United Nations [International Academy of Astronautics](http://iaaweb.org/). She directs two startups: [In Unison](https://inunison.org/), a charity that promotes peace and social justice through education and music, and [Open Data Collaboratives](http://africaopendata.net/), creating education programs for innovators throughout Africa.

--- a/src/_posts/2018-04-11-data-donuts-12.md
+++ b/src/_posts/2018-04-11-data-donuts-12.md
@@ -2,8 +2,8 @@
 layout: post
 
 #event information
-title:  "Data + Donuts @ LACI"
-date:   2018-04-11 08:00+0800
+title: "Data + Donuts @ LACI"
+date: 2018-04-11 08:00
 start_time: "8:00am"
 end_time: "10:00am"
 
@@ -21,7 +21,9 @@ video: ""
 This month the [Southern California Association of Governments](http://www.scag.ca.gov/Pages/default.aspx) will present on its [Future Communities Initiative](https://www.scag.ca.gov/Documents/Final_scagFutureCommunitiesFramework.pdf) and current regional data projects, including the Local Input Process, the Active Transportation Database, and a new crowd sourcing app for transit supportive development.
 
 #### About Rye Baerg
+
 Rye Baerg is a Senior Regional Planner in the Active Transportation and Special Programs Department at the Southern California Association of Governments (SCAG). At SCAG Rye oversees a variety of projects and programs related to public health, active transportation and data collection. Prior to SCAG, Rye worked on active transportation policy and projects for the Safe Routes to School National Partnership, the Los Angeles County Metropolitan Transportation Authority, and the Los Angeles Department of City Planning. Rye received his Bachelors of Arts in Anthropology and a Masters of Urban Planning, both from the University of California Los Angeles (UCLA).
 
 #### About Kimberly Clark
+
 Kimberly Clark is an Urban Planner at the Southern California Association of Governments (SCAG), and specializes in regional data science, geographic information systems (GIS), and interactive data visualization. As a public agency, SCAG works with various regional partners to develop long-range transportation, housing, and sustainability plans that transcend jurisdictional boundaries and improve the quality of life for Southern Californians. In her current work, Ms. Clark is leading the Bottom-Up Local Input and Envisioning Process for SCAG’s 2020 Regional Transportation Plan and Sustainable Communities Strategy (RTP/SCS), which involves the development and refinement of the base socioeconomic and geographic datasets for the upcoming Plan. Ms. Clark holds an undergraduate degree in political science from University of California, Riverside and a Master’s degree in urban planning from UCLA.

--- a/src/_posts/2018-05-09-data-donuts-13.md
+++ b/src/_posts/2018-05-09-data-donuts-13.md
@@ -2,8 +2,8 @@
 layout: post
 
 #event information
-title:  "Data + Donuts @ LACI"
-date:   2018-05-09 08:00+0800
+title: "Data + Donuts @ LACI"
+date: 2018-05-09 08:00
 start_time: "8:00am"
 end_time: "10:00am"
 
@@ -17,9 +17,8 @@ slides: ""
 video: ""
 ---
 
-
-The County of Los Angeles has thousands of contracts active at any given time, accounting for millions of dollars of the County’s budget.  These contracts are spread out over 30+ departments and cover a variety of services ranging from traffic management systems to emergency child care.  What are the data challenges involved, and what is the County doing to address them?  This presentation will be about one ongoing effort to tackle these issues.
+The County of Los Angeles has thousands of contracts active at any given time, accounting for millions of dollars of the County’s budget. These contracts are spread out over 30+ departments and cover a variety of services ranging from traffic management systems to emergency child care. What are the data challenges involved, and what is the County doing to address them? This presentation will be about one ongoing effort to tackle these issues.
 
 #### About Nina Kin
 
-Nina Kin has worked for over a decade as a Systems Analyst at the County of Los Angeles Department of Auditor-Controller.  She takes on roles ranging from code monkey to stakeholder wrangler in order to implement web applications that improve the County’s efficiency.  As an organizer of Hack for LA and MaptimeLA, she is also enthusiastic about open data and community engagement.  She earned her Bachelors of Science in Electrical Engineering and Computer Science from the University of California, Berkeley.
+Nina Kin has worked for over a decade as a Systems Analyst at the County of Los Angeles Department of Auditor-Controller. She takes on roles ranging from code monkey to stakeholder wrangler in order to implement web applications that improve the County’s efficiency. As an organizer of Hack for LA and MaptimeLA, she is also enthusiastic about open data and community engagement. She earned her Bachelors of Science in Electrical Engineering and Computer Science from the University of California, Berkeley.

--- a/src/_posts/2018-06-13-data-donuts-14.md
+++ b/src/_posts/2018-06-13-data-donuts-14.md
@@ -2,8 +2,8 @@
 layout: post
 
 #event information
-title:  "Data + Donuts @ LACI"
-date:   2018-06-13 08:00+0800
+title: "Data + Donuts @ LACI"
+date: 2018-06-13 08:00
 start_time: "8:00am"
 end_time: "10:00am"
 
@@ -18,7 +18,7 @@ slides: ""
 video: ""
 ---
 
-The City of Los Angeles launched an ambitious project to modernize zoning codes and the way we interact with them in Los Angeles.  Join us for a talk with the team behind the project and learn about [re:code LA](https://recode.la/) - the process, the tech behind it, the decision to open source the final product.
+The City of Los Angeles launched an ambitious project to modernize zoning codes and the way we interact with them in Los Angeles. Join us for a talk with the team behind the project and learn about [re:code LA](https://recode.la/) - the process, the tech behind it, the decision to open source the final product.
 
 #### About Erin Coleman
 

--- a/src/_posts/2018-07-19-data-donuts-15.md
+++ b/src/_posts/2018-07-19-data-donuts-15.md
@@ -2,8 +2,8 @@
 layout: post
 
 #event information
-title:  "Data + Donuts @ LACI"
-date:   2018-07-19 08:00+0800
+title: "Data + Donuts @ LACI"
+date: 2018-07-19 08:00
 start_time: "8:00am"
 end_time: "10:00am"
 

--- a/src/_posts/2018-09-13-data-donuts-16.md
+++ b/src/_posts/2018-09-13-data-donuts-16.md
@@ -2,8 +2,8 @@
 layout: post
 
 #event information
-title:  "Data + Donuts @ LACI"
-date:   2018-09-13 08:00+0800
+title: "Data + Donuts @ LACI"
+date: 2018-09-13 08:00
 start_time: "8:00am"
 end_time: "10:00am"
 
@@ -17,10 +17,10 @@ slides: ""
 video: ""
 ---
 
-L.A. County's Internal Services Department has recently deployed an open-source Data Lake based on the Hadoop ecosystem.  Jon Neill,  Program Manager for ISD's Data Analytics Team will discuss the vision, approach, and challenges in rolling out a modern data analytics platform in a large multi-departmental, multi-stakeholder governmental agency. 
+L.A. County's Internal Services Department has recently deployed an open-source Data Lake based on the Hadoop ecosystem. Jon Neill, Program Manager for ISD's Data Analytics Team will discuss the vision, approach, and challenges in rolling out a modern data analytics platform in a large multi-departmental, multi-stakeholder governmental agency.
 
 #### About Jon Neill
 
-With over 30 years of IT experience at the County of Los Angeles, Jon Neill has been a visionary and technology leader at both the Internal Services Department (ISD) and the Auditor-Controller. Jon is currently a Senior IT Specialist in ISD’s Customer Applications Branch leading the Data Analytics and Business Intelligence team.   He is spearheading ISD’s transformation on how technology is delivered to its customers including Big Data, Agile, and DevOps programs, pushing the County towards becoming a modern digital organization.
+With over 30 years of IT experience at the County of Los Angeles, Jon Neill has been a visionary and technology leader at both the Internal Services Department (ISD) and the Auditor-Controller. Jon is currently a Senior IT Specialist in ISD’s Customer Applications Branch leading the Data Analytics and Business Intelligence team. He is spearheading ISD’s transformation on how technology is delivered to its customers including Big Data, Agile, and DevOps programs, pushing the County towards becoming a modern digital organization.
 
 Jon is also involved in civic technology outreach bringing government technology workers together and is a founding organizer of Data and Donuts. Jon is an avid golfer, curler, and computer gamer.

--- a/src/_posts/2018-10-11-data-donuts-17.md
+++ b/src/_posts/2018-10-11-data-donuts-17.md
@@ -2,8 +2,8 @@
 layout: post
 
 #event information
-title:  "Data + Donuts @ LACI"
-date:   2018-10-11 08:00+0800
+title: "Data + Donuts @ LACI"
+date: 2018-10-11 08:00
 start_time: "8:00am"
 end_time: "10:00am"
 
@@ -23,7 +23,7 @@ Scoot scoot! Scooter wars rage in LA. Join us next week to find out how a humble
 
 #### About Hunter Owens
 
-Hunter Owens is the Senior Data Scientist at the City of Los Angeles [Information Technology Agency](http://ita.lacity.org/). Prior to joining the City, he worked for the University of Chicago's Center for Data Science and Public Policy, KIPP NJ, and Obama for America. You can find on [Github](http://github.com/hunterowens) and [Twitter](https://twitter.com/hunter_owens) 
+Hunter Owens is the Senior Data Scientist at the City of Los Angeles [Information Technology Agency](http://ita.lacity.org/). Prior to joining the City, he worked for the University of Chicago's Center for Data Science and Public Policy, KIPP NJ, and Obama for America. You can find on [Github](http://github.com/hunterowens) and [Twitter](https://twitter.com/hunter_owens)
 
 #### About Kegan Maher
 

--- a/src/_posts/2018-11-13-data-donuts-18.md
+++ b/src/_posts/2018-11-13-data-donuts-18.md
@@ -2,8 +2,8 @@
 layout: post
 
 #event information
-title:  "Data + Donuts @ LACI"
-date:   2018-11-13 08:00+0800
+title: "Data + Donuts @ LACI"
+date: 2018-11-13 08:00
 start_time: "8:00am"
 end_time: "10:00am"
 
@@ -16,6 +16,7 @@ eventbrite: "//eventbrite.com/tickets-external?eid=52074907450&ref=etckt"
 slides: ""
 video: ""
 ---
+
 Please join Data + Donuts for our first event in a series about aerial imagery in Los Angeles.
 
 We're thrilled to hear from Javier Aguilar, Senior Regional Planner at Southern California Association of Governments (SCAG). Javier will discuss the Regional Aerial Imagery Initiative, a new collaborative project that will enable regional cities, counties, and other stakeholders to pool resources for high-resolution aerial imagery.
@@ -23,4 +24,5 @@ We're thrilled to hear from Javier Aguilar, Senior Regional Planner at Southern 
 This imagery and reference data will be collected in early 2020 and will would provide a critical baseline reference for the 2020 U.S. Decennial Census and the 2024 Regional Transportation Plan and Sustainable Communities Strategy.
 
 #### About Javier Aguilar
+
 Javier Aguilar is a Senior Regional Planner in the Research and Analysis Department at the Southern California Association of Governments (SCAG). At SCAG, Javier oversees the agency’s GIS Services Program which provides services, training, software, hardware, and data to its local jurisdictions. Prior to SCAG, he worked in the private and non-profit sectors on various transportation, economic development, and environmental planning projects. Javier holds a Bachelors of Arts in Latin American Studies from Loyola Marymount University and two Master’s degree in Latin American Studies and Urban Planning for the University of California, Los Angeles (UCLA).

--- a/src/_posts/2018-12-11-data-donuts-19.md
+++ b/src/_posts/2018-12-11-data-donuts-19.md
@@ -2,8 +2,8 @@
 layout: post
 
 #event information
-title:  "Data + Donuts @ LACI"
-date:   2018-12-11 08:00+0800
+title: "Data + Donuts @ LACI"
+date: 2018-12-11 08:00
 start_time: "8:00am"
 end_time: "10:00am"
 
@@ -21,8 +21,8 @@ Join us this month to hear from Mohammed Al Rawi, on the applications of machine
 
 #### About Mohammed Al Rawi
 
-Mohammed Al Rawi is the Chief Information Officer for the L.A. County Department of Parks and Recreation. He is in charge of leading the development, modernization, assessment and ongoing analysis of information technology, information security governance, data management and reporting systems supporting the department’s 2,700 employee workforce. Mr. Al Rawi is also the Chairman of the Los Angeles County Innovation and Emerging Technology Commission. 
+Mohammed Al Rawi is the Chief Information Officer for the L.A. County Department of Parks and Recreation. He is in charge of leading the development, modernization, assessment and ongoing analysis of information technology, information security governance, data management and reporting systems supporting the department’s 2,700 employee workforce. Mr. Al Rawi is also the Chairman of the Los Angeles County Innovation and Emerging Technology Commission.
 
-Mr. Al Rawi has brought many award-winning innovative solutions to transform business processes and to solve complex, life-saving, business challenges. Mr. Al Rawi was named one of Government Technology's Top 25 Doers, Dreamers and Drivers for 2018. 
+Mr. Al Rawi has brought many award-winning innovative solutions to transform business processes and to solve complex, life-saving, business challenges. Mr. Al Rawi was named one of Government Technology's Top 25 Doers, Dreamers and Drivers for 2018.
 
 In addition to his passion for auto racing, Mr. Al Rawi is a computer scientist who enjoys coding and application development in his spare time.

--- a/src/_posts/2019-02-19-data-donuts-20.md
+++ b/src/_posts/2019-02-19-data-donuts-20.md
@@ -2,8 +2,8 @@
 layout: post
 
 #event information
-title:  "Data + Donuts @ LACI"
-date:   2019-02-19 08:00+0800
+title: "Data + Donuts @ LACI"
+date: 2019-02-19 08:00
 start_time: "8:00am"
 end_time: "10:00am"
 
@@ -19,11 +19,13 @@ video: ""
 ---
 
 #### About Son Htet
+
 Son Htet is a data analyst working in the FireStatLA section. His work focuses on analyzing the workload
 and response times for different units, stations and areas covered by the Los Angeles Fire Department,
 as well as producing interactive reports and visualizations for operational use.
 
 #### About Anthony Guerrero
+
 Anthony Guerrero is a data analyst who works with internal and public-facing Fire Department data. His
 work focuses on improving data accessibility for performance metrics, grants, and budgeting for the
 department.

--- a/src/_posts/2019-03-12-data-donuts-21.md
+++ b/src/_posts/2019-03-12-data-donuts-21.md
@@ -2,8 +2,8 @@
 layout: post
 
 #event information
-title:  "Data + Donuts @ LACI"
-date:   2019-03-12 08:00+0800
+title: "Data + Donuts @ LACI"
+date: 2019-03-12 08:00
 start_time: "8:00am"
 end_time: "10:00am"
 
@@ -17,9 +17,7 @@ slides: ""
 video: ""
 ---
 
-
-
-In 2017 the [LA County Arts Commission](https://www.lacountyarts.org/) launched the county’s first datathon focused entirely on improving access to the arts, in partnership with the City of LA’s Department of Cultural Affairs. The third annual Arts Datathon takes place on April 2019 and will focus on *democratizing arts data*. Join us to learn how they’re making data more accessible and useful to LA’s vibrant arts and culture communities, and how you can participate. [artsdatathon.org](https://artsdatathon.org/)
+In 2017 the [LA County Arts Commission](https://www.lacountyarts.org/) launched the county’s first datathon focused entirely on improving access to the arts, in partnership with the City of LA’s Department of Cultural Affairs. The third annual Arts Datathon takes place on April 2019 and will focus on _democratizing arts data_. Join us to learn how they’re making data more accessible and useful to LA’s vibrant arts and culture communities, and how you can participate. [artsdatathon.org](https://artsdatathon.org/)
 
 ## About Bronwyn Mauldin
 

--- a/src/_posts/2019-05-14-data-donuts-22.md
+++ b/src/_posts/2019-05-14-data-donuts-22.md
@@ -2,8 +2,8 @@
 layout: post
 
 #event information
-title:  "Data + Donuts @ LACI"
-date:   2019-05-14 08:00+0800
+title: "Data + Donuts @ LACI"
+date: 2019-05-14 08:00
 start_time: "8:00am"
 end_time: "10:00am"
 

--- a/src/_posts/2019-06-11-data-donuts-23.md
+++ b/src/_posts/2019-06-11-data-donuts-23.md
@@ -2,8 +2,8 @@
 layout: post
 
 #event information
-title:  "Data + Donuts @ LACI"
-date:   2019-06-11 08:00+0800
+title: "Data + Donuts @ LACI"
+date: 2019-06-11 08:00
 start_time: "8:00am"
 end_time: "10:00am"
 

--- a/src/_posts/2019-07-11-data-donuts-24.md
+++ b/src/_posts/2019-07-11-data-donuts-24.md
@@ -2,8 +2,8 @@
 layout: post
 
 #event information
-title:  "Data + Donuts @ LACI"
-date:   2019-07-11 08:00+0800
+title: "Data + Donuts @ LACI"
+date: 2019-07-11 08:00
 start_time: "8:00am"
 end_time: "10:00am"
 
@@ -18,7 +18,6 @@ video: "www.youtube.com/embed/hmmaOgBW8oo"
 ---
 
 The Los Angeles County Office of the CIO worked closely with the 37 County departments to develop 5 priority Enterprise IT Strategic Goals including ‘Data as a Utility’. This goal is defined as enabling the use and accessibility of data to build a countywide culture that emphasizes data-driven decision making. County CIO Bill Kehoe will discuss the responsibility of being the countywide Stewards of Data and how his department is working to achieve the goal of Data as a Utility.
-
 
 ## About Bill Kehoe
 

--- a/src/_posts/2019-08-13-data-donuts-25.md
+++ b/src/_posts/2019-08-13-data-donuts-25.md
@@ -2,8 +2,8 @@
 layout: post
 
 #event information
-title:  "Data + Donuts @ LACI"
-date:   2019-08-13 08:00+0800
+title: "Data + Donuts @ LACI"
+date: 2019-08-13 08:00
 start_time: "8:00am"
 end_time: "10:00am"
 
@@ -23,6 +23,6 @@ Security and privacy are inherently connected. Our digital footprint is part of 
 
 In 2015 Alex Alben was named as the first Chief Privacy Officer for the State of Washington and lead the state’s Office of Privacy and Data Protection for more than 4 years. In that role, he initiated state-wide programs for enhanced privacy training, consumer education and launched “Privacy Modeling” for over 50 state agencies. He also co-chaired the state’s Autonomous Vehicle committee on System Technology & Data Security which examined new technologies such as drones, biometrics and data-sharing applications.
 
-Alex played a leadership role in the field of digital media and has shared his expertise in both teaching and journalism. As a technology executive, Alex helped launch ESPN.com and ABCNews.com, and served for six years in senior management at RealNetworks. At the outset of his career, Alben served as a researcher for CBS News covering Presidential campaigns and went on to work for Mike Wallace at CBS Reports. Alben worked as an entertainment lawyer for Orion Pictures and Warner Bros. 
+Alex played a leadership role in the field of digital media and has shared his expertise in both teaching and journalism. As a technology executive, Alex helped launch ESPN.com and ABCNews.com, and served for six years in senior management at RealNetworks. At the outset of his career, Alben served as a researcher for CBS News covering Presidential campaigns and went on to work for Mike Wallace at CBS Reports. Alben worked as an entertainment lawyer for Orion Pictures and Warner Bros.
 
 A graduate of Stanford University and Stanford Law School, Alben writes for The Seattle Times and other publications on the intersection of media, technology, and politics. He is the author of Analog Days—How Technology Rewrote Our Future. He is a veteran professors at the University of Washington and will soon begin teaching a course on Privacy, Data, and Technology at UCLA School of Law.

--- a/src/_posts/2019-09-17-data-donuts-26.md
+++ b/src/_posts/2019-09-17-data-donuts-26.md
@@ -2,8 +2,8 @@
 layout: post
 
 #event information
-title:  "Data + Donuts @ LACI"
-date:   2019-09-17 08:00+0800
+title: "Data + Donuts @ LACI"
+date: 2019-09-17 08:00
 start_time: "8:00am"
 end_time: "10:00am"
 
@@ -21,10 +21,10 @@ The City of Los Angeles Office of Finance is pushing technology to make real imp
 
 ## About Juan Vasquez
 
-As Data Programs Manager at the Office of Finance, Juan is a leader in modernizing and optimizing how the 400-person department collects, reports, manages, and uses data, and more importantly the actionable insights derived from it. Some days, he builds map-based tools to provide business intelligence for decision makers and organizational leaders, other days he is writing SQL queries to feed data into email newsletters or the digitization of traditional paper processes, and sometimes he is working with stakeholder groups to achieve systematic improvements. 
+As Data Programs Manager at the Office of Finance, Juan is a leader in modernizing and optimizing how the 400-person department collects, reports, manages, and uses data, and more importantly the actionable insights derived from it. Some days, he builds map-based tools to provide business intelligence for decision makers and organizational leaders, other days he is writing SQL queries to feed data into email newsletters or the digitization of traditional paper processes, and sometimes he is working with stakeholder groups to achieve systematic improvements.
 
 Juan's worked is heavily focused around using data to improve the overall customer experience for internal and external stakeholders. Prior to joining Finance, Juan was a data analyst at the Mayor's Office. During the last 4 years working within LA's local government, Juan was worked with data on a variety of diverse topics: from cannabis to real estate, workers' comp, procurement, and business.
 
-Juan's career started in the private sector back in 2010, working as an advertising agency account exec, where he learned the value of strategic communication, framing, design, and user experience. He also worked at a DTLA tech company, NationBuilder, where he helped hundreds of nonprofits, governments, and political campaigns configure their databases and improve their digital organizing efforts. During his free time Juan teaches data analytics and visualization classes at General Assembly. 
+Juan's career started in the private sector back in 2010, working as an advertising agency account exec, where he learned the value of strategic communication, framing, design, and user experience. He also worked at a DTLA tech company, NationBuilder, where he helped hundreds of nonprofits, governments, and political campaigns configure their databases and improve their digital organizing efforts. During his free time Juan teaches data analytics and visualization classes at General Assembly.
 
 He is originally from Bogota, Colombia and is a proud immigrant. He and his wife are homeowners and live in Boyle Heights, the same neighborhood Juan has lived in since moving to LA almost 7 years ago.

--- a/src/_posts/2019-10-10-data-donuts-27.md
+++ b/src/_posts/2019-10-10-data-donuts-27.md
@@ -2,8 +2,8 @@
 layout: post
 
 #event information
-title:  "Data + Donuts @ LACI"
-date:   2019-10-10 08:00+0800
+title: "Data + Donuts @ LACI"
+date: 2019-10-10 08:00
 start_time: "8:00am"
 end_time: "10:00am"
 
@@ -16,7 +16,6 @@ eventbrite: "https://eventbrite.com/tickets-external?eid=75013873515&ref=etckt"
 slides: ""
 video: ""
 ---
-
 
 ## About Marisa Laderach
 

--- a/src/_posts/2019-11-05-data-donuts-28.md
+++ b/src/_posts/2019-11-05-data-donuts-28.md
@@ -2,8 +2,8 @@
 layout: post
 
 #event information
-title:  "Data + Donuts @ LACI"
-date:   2019-11-05 08:00+0800
+title: "Data + Donuts @ LACI"
+date: 2019-11-05 08:00
 start_time: "8:00am"
 end_time: "10:00am"
 
@@ -17,7 +17,6 @@ eventbrite: "https://eventbrite.com/tickets-external?eid=75014162379&ref=etckt"
 slides: ""
 video: ""
 ---
-
 
 ## About Bobby Kobara
 

--- a/src/_posts/2019-12-10-data-donuts-29.md
+++ b/src/_posts/2019-12-10-data-donuts-29.md
@@ -2,8 +2,8 @@
 layout: post
 
 #event information
-title:  "Data + Donuts @ LACI"
-date:   2019-12-10 08:00+0800
+title: "Data + Donuts @ LACI"
+date: 2019-12-10 08:00
 start_time: "8:00am"
 end_time: "10:00am"
 
@@ -22,14 +22,13 @@ Join us in December to get a crash course in Data Science at the City of Los Ang
 
 ## About Tiffany Chu
 
-Tiffany Chu is a data analyst at ITA. In a previous life, she was a tranpo-nerd, passionate about public transit, and working in transportation consulting. Now, she provides other City departments the data insights needed to change their operations.   
+Tiffany Chu is a data analyst at ITA. In a previous life, she was a tranpo-nerd, passionate about public transit, and working in transportation consulting. Now, she provides other City departments the data insights needed to change their operations.
 
 LinkedIn: [https://www.linkedin.com/in/tiffanychu90/](https://www.linkedin.com/in/tiffanychu90/)
 
-
 ## About Ian Rose
 
-Ian Rose received a Ph.D. in Geophysics from UC Berkeley, during which time he became involved in the open source scientific software community. Since then he has been doing data science and open source software engineering at the Berkeley Institute for Data Science, Quansight, and most recently the City of Los Angeles. He is a core developer of JupyterLab, and an active member of the dask, intake, and Python GIS communities. 
+Ian Rose received a Ph.D. in Geophysics from UC Berkeley, during which time he became involved in the open source scientific software community. Since then he has been doing data science and open source software engineering at the Berkeley Institute for Data Science, Quansight, and most recently the City of Los Angeles. He is a core developer of JupyterLab, and an active member of the dask, intake, and Python GIS communities.
 
 Blog: [https://ian-r-rose.github.io/](https://ian-r-rose.github.io/)
 GitHub: [https://github.com/ian-r-rose/](https://github.com/ian-r-rose/)

--- a/src/_posts/2020-01-21-data-donuts-30.md
+++ b/src/_posts/2020-01-21-data-donuts-30.md
@@ -2,8 +2,8 @@
 layout: post
 
 #event information
-title:  "Data + Donuts @ LACI"
-date:   2020-01-21 08:00+0800
+title: "Data + Donuts @ LACI"
+date: 2020-01-21 08:00
 start_time: "8:00am"
 end_time: "10:00am"
 
@@ -17,8 +17,8 @@ slides: ""
 video: ""
 ---
 
-Join us as Jonathan Bentley will discuss how LASAN uses data analytics and reporting to tackle the important issues of the day.  Using Tableau, he blends data from both internal and external sources to create meaningful and actionable reports that allow managers to swiftly adjust strategies and deploy resources for the City's benefit. 
+Join us as Jonathan Bentley will discuss how LASAN uses data analytics and reporting to tackle the important issues of the day. Using Tableau, he blends data from both internal and external sources to create meaningful and actionable reports that allow managers to swiftly adjust strategies and deploy resources for the City's benefit.
 
 ## About Jonathan Bentley
 
-Jonathan Bentley analyzed and reported data for companies such as Princess Cruises, Hilton Hotels Corporation and Public Storage for 20 years before joining the team at Los Angeles Sanitation & Environment.  Jonathan is motivated to use his experience and skillset to tackle meaningful issues that impact people every day. Find him on [LinkedIn](https://www.linkedin.com/in/jonathan-bentley-51b26311/).
+Jonathan Bentley analyzed and reported data for companies such as Princess Cruises, Hilton Hotels Corporation and Public Storage for 20 years before joining the team at Los Angeles Sanitation & Environment. Jonathan is motivated to use his experience and skillset to tackle meaningful issues that impact people every day. Find him on [LinkedIn](https://www.linkedin.com/in/jonathan-bentley-51b26311/).

--- a/src/_posts/2020-04-30-data-donuts-32.md
+++ b/src/_posts/2020-04-30-data-donuts-32.md
@@ -2,8 +2,8 @@
 layout: post
 
 #event information
-title:  "Data + Donuts Virtual Webinar"
-date:   2020-04-30 08:00+0800
+title: "Data + Donuts Virtual Webinar"
+date: 2020-04-30 08:00
 start_time: "8:30am"
 end_time: "10:00am"
 
@@ -17,7 +17,8 @@ slides: ""
 video: ""
 ---
 
-As many government agencies are diving into remote work for the very first time, this month Vyki Englert is going to host a crash course in working remote for government agencies. She’ll cover how to author a telework policy, selecting and new configuring tools, and establishing expectations and new cultural norms. Vyki is also authoring [a guide to remote and telework for governments](https://docs.google.com/document/d/1XXtamHd_diCfDfODuIYh2YnfgxnJGpvaMr3vuSwsF-w/edit#heading=h.j0uxv2qq9wt1) full of resources from local, state, and federal agencies and example policies.  
+As many government agencies are diving into remote work for the very first time, this month Vyki Englert is going to host a crash course in working remote for government agencies. She’ll cover how to author a telework policy, selecting and new configuring tools, and establishing expectations and new cultural norms. Vyki is also authoring [a guide to remote and telework for governments](https://docs.google.com/document/d/1XXtamHd_diCfDfODuIYh2YnfgxnJGpvaMr3vuSwsF-w/edit#heading=h.j0uxv2qq9wt1) full of resources from local, state, and federal agencies and example policies.
 
 ## About Vyki Englert
-Vyki Englert is Principal and Co-Founder of Compiler LA, a civic tech agency dedicated to building a better Los Angeles. Through Compiler her work has included serving as an ambassador for the state’s open data program, developing web applications for clients such as City of Los Angeles, State of California Health and Human Services, and the California Community Foundation, and hosting the popular Data and Donuts and School of Data events in Los Angeles. By night she’s a co-founder of Policy Club, a small group of volunteers publishing data analysis and advocating for smarter CA state policy.  She previously served as a member of Code for America’s National Advisory Council, and is an advisor to govtech startup CityGrows. Find her on [LinkedIn](https://www.linkedin.com/in/vykienglert/) and [Twitter](https://twitter.com/vyki_e).
+
+Vyki Englert is Principal and Co-Founder of Compiler LA, a civic tech agency dedicated to building a better Los Angeles. Through Compiler her work has included serving as an ambassador for the state’s open data program, developing web applications for clients such as City of Los Angeles, State of California Health and Human Services, and the California Community Foundation, and hosting the popular Data and Donuts and School of Data events in Los Angeles. By night she’s a co-founder of Policy Club, a small group of volunteers publishing data analysis and advocating for smarter CA state policy. She previously served as a member of Code for America’s National Advisory Council, and is an advisor to govtech startup CityGrows. Find her on [LinkedIn](https://www.linkedin.com/in/vykienglert/) and [Twitter](https://twitter.com/vyki_e).

--- a/src/_posts/2020-08-25-data-donuts-33.md
+++ b/src/_posts/2020-08-25-data-donuts-33.md
@@ -2,15 +2,15 @@
 layout: post
 
 #event information
-title:  "Data + Donuts Virtual Webinar"
-date:   2020-08-25 08:30+0800
+title: "Data + Donuts Virtual Webinar"
+date: 2020-08-25 08:30
 start_time: "8:30am"
 end_time: "10:00am"
 
 location: VIRTUAL
 cover: "/images/data-donuts-tiling-bg.png"
 
-speakers: 
+speakers:
   - "Logan Nash"
   - "Conan Cheung"
 eventbrite: "https://eventbrite.com/tickets-external?eid=117433030355&ref=etckt"
@@ -18,14 +18,16 @@ slides: ""
 video: ""
 ---
 
-The COVID-19 pandemic turned crowding into a priority for transit agencies overnight: essential workers and vulnerable communities continue to depend on buses and trains in a time of unprecedented personal and global anxiety. 
+The COVID-19 pandemic turned crowding into a priority for transit agencies overnight: essential workers and vulnerable communities continue to depend on buses and trains in a time of unprecedented personal and global anxiety.
 
-After the pandemic began, the MBTA in Boston was quickly able to launch real-time crowding data for its bus riders, becoming the largest transit agency in the country to make this kind of information available on local buses. Logan Nash from the MBTA will talk about the user research, technology, and frustrations of making crowding information available to riders (and front-line operations staff) on a very short timeline. 
+After the pandemic began, the MBTA in Boston was quickly able to launch real-time crowding data for its bus riders, becoming the largest transit agency in the country to make this kind of information available on local buses. Logan Nash from the MBTA will talk about the user research, technology, and frustrations of making crowding information available to riders (and front-line operations staff) on a very short timeline.
 
-LA Metro will share how new data and technologies are being used to guide operational decisions to reduce crowding system-wide and increase safety for riders and operators. 
+LA Metro will share how new data and technologies are being used to guide operational decisions to reduce crowding system-wide and increase safety for riders and operators.
 
 ## About Logan Nash
-Logan Nash is the Deputy Director of Realtime Applications at the Massachusetts Bay Transportation Authority (MBTA) in Boston. As part of the MBTA’s Customer Technology Department, Logan’s team is responsible for real-time information and associated operations tools such as Skate, the MBTA’s mobile bus dispatch app. Arrival predictions, real-time locations, and other info from these systems drive modern rider tools like mbta.com and digital screens, as well as third-party apps via the agency’s open APIs. 
+
+Logan Nash is the Deputy Director of Realtime Applications at the Massachusetts Bay Transportation Authority (MBTA) in Boston. As part of the MBTA’s Customer Technology Department, Logan’s team is responsible for real-time information and associated operations tools such as Skate, the MBTA’s mobile bus dispatch app. Arrival predictions, real-time locations, and other info from these systems drive modern rider tools like mbta.com and digital screens, as well as third-party apps via the agency’s open APIs.
 
 ## About Conan Cheung
+
 Conan Cheung serves as Senior Executive Officer – Service Development at Metro. He is responsible for bus and rail service changes, systemwide service policies, and performance analysis including ridership trends. Prior to Metro, he was Director of Planning and Scheduling with San Diego MTS, and worked for transportation planning organizations in the SF Bay Area.  Mr. Cheung received his BS in Urban Planning and Public Administration from the USC and MA in Urban Planning from UCLA.

--- a/src/_posts/2020-12-10-data-donuts-34.md
+++ b/src/_posts/2020-12-10-data-donuts-34.md
@@ -2,8 +2,8 @@
 layout: post
 
 #event information
-title:  "Data + Donuts @ LACI"
-date:   2020-12-10 08:00+0800
+title: "Data + Donuts @ LACI"
+date: 2020-12-10 08:00
 start_time: "9:00am"
 end_time: "10:00am"
 
@@ -11,8 +11,8 @@ location: VIRTUAL
 cover: "/images/data-donuts-tiling-bg.png"
 
 #event organiser aka speaker details
-speakers: 
- - "Chris Pailma"
+speakers:
+  - "Chris Pailma"
 eventbrite: "https://eventbrite.com/tickets-external?eid=131534726909&ref=etckt"
 slides: ""
 video: "https://youtu.be/embed/rd5dOu7kCE8"
@@ -24,7 +24,7 @@ This month Chris Pailma head of L.A. County ISD’s Cloud Development Team will 
 
 ## About Chris Pailma
 
-Christopher “Chris” Pailma is an innovative leader with a wealth of experience managing transformational technical projects in the local Government sector. 
+Christopher “Chris” Pailma is an innovative leader with a wealth of experience managing transformational technical projects in the local Government sector.
 
 Chris has 20+ years of experience in the field of information technology with demonstrated proficiency in managing, directing, architecting, designing, and implementing highly complex information technology solutions working with Federal, State, and County agencies. Chris has worked on large enterprise computer information systems in Master Data Management, Higher Education, Court Systems, Document Recording, and Election Systems. Chris currently leads a team of application developers at the Internal Service Department (ISD) that is focused on leading Los Angeles County into modern cloud platforms and technologies.
 

--- a/src/_posts/2021-09-15-data-donuts-35.md
+++ b/src/_posts/2021-09-15-data-donuts-35.md
@@ -2,8 +2,8 @@
 layout: post
 
 #event information
-title:  "Data + Donuts is Back!"
-date:   2021-09-15 08:00+0800
+title: "Data + Donuts is Back!"
+date: 2021-09-15 08:00
 start_time: "10:30am"
 end_time: "11:30am"
 
@@ -11,9 +11,9 @@ location: VIRTUAL
 cover: "/images/data-donuts-tiling-bg.png"
 
 #event organiser aka speaker details
-speakers: 
- - "India Brookover"
- - "Lorianne Esturas"
+speakers:
+  - "India Brookover"
+  - "Lorianne Esturas"
 eventbrite: "https://eventbrite.com/tickets-external?eid=170083088095&ref=etckt"
 slides: ""
 video: ""

--- a/src/_posts/2023-06-13-data-donuts-36.md
+++ b/src/_posts/2023-06-13-data-donuts-36.md
@@ -2,8 +2,8 @@
 layout: post
 
 #event information
-title:  "Digital Identity with CDT and Login.gov"
-date:   2023-06-13 08:00+0800
+title: "Digital Identity with CDT and Login.gov"
+date: 2023-06-13 08:00
 start_time: "08:00am"
 end_time: "10:00am"
 
@@ -11,8 +11,8 @@ location: LACI
 cover: ../images/la-kretz-campus.jpeg
 
 #event speaker details
-speakers: 
- - "Jarrett Krumrei"
+speakers:
+  - "Jarrett Krumrei"
 eventbrite: "https://eventbrite.com/tickets-external?eid=628595364657&ref=etckt"
 slides: ""
 video: ""
@@ -20,7 +20,7 @@ video: ""
 
 California Digital Identity: Piloting Digital Identity with the State of California
 
-The California Department of Technology's Digitial Identity team (CDT D-ID) is tasked with exploring options to provide a consistent, secure, privacy enabled, reliable, and consent-based method to authenticate and verify the identity of a California resident when accessing public services. Join us this month to learn about D-ID's partnership with Login.gov and their agile approach to implementing digital identity with partner agencies to reduce the burden on Californians verifying age to access public benefits. 
+The California Department of Technology's Digitial Identity team (CDT D-ID) is tasked with exploring options to provide a consistent, secure, privacy enabled, reliable, and consent-based method to authenticate and verify the identity of a California resident when accessing public services. Join us this month to learn about D-ID's partnership with Login.gov and their agile approach to implementing digital identity with partner agencies to reduce the burden on Californians verifying age to access public benefits.
 
 ## About Jarrett Krumrei
 

--- a/src/_posts/2023-08-29-data-donuts-37.md
+++ b/src/_posts/2023-08-29-data-donuts-37.md
@@ -2,8 +2,8 @@
 layout: post
 
 #event information
-title:  "Customer Experience with LA Metro"
-date:   2023-08-29 08:00+0800
+title: "Customer Experience with LA Metro"
+date: 2023-08-29 08:00
 start_time: "08:00am"
 end_time: "10:00am"
 
@@ -11,8 +11,8 @@ location: LACI
 cover: ../images/la-kretz-campus.jpeg
 
 #event speaker details
-speakers: 
- - "Lauren Deaderick"
+speakers:
+  - "Lauren Deaderick"
 eventbrite: "https://eventbrite.com/tickets-external?eid=691215222337&ref=etckt"
 slides: ""
 video: ""

--- a/src/_posts/2023-10-04-data-donuts-38.md
+++ b/src/_posts/2023-10-04-data-donuts-38.md
@@ -2,8 +2,8 @@
 layout: post
 
 #event information
-title:  "California Transit Speed Maps with Caltrans"
-date:   2023-10-04 08:00+0800
+title: "California Transit Speed Maps with Caltrans"
+date: 2023-10-04 08:00
 start_time: "08:00am"
 end_time: "10:00am"
 
@@ -11,8 +11,8 @@ location: LACI
 cover: ../images/la-kretz-campus.jpeg
 
 #event speaker details
-speakers: 
- - "Eric Dasmalchi"
+speakers:
+  - "Eric Dasmalchi"
 eventbrite: "https://eventbrite.com/tickets-external?eid=726415417067&ref=etckt"
 slides: ""
 video: ""
@@ -21,6 +21,7 @@ video: ""
 ## Iterating on California Transit Speed Maps: from GTFS Data to Useful Analytics
 
 Hear how Caltrans’ new Division of Data and Digital Services has leveraged open standards such as the General Transit Feed Specification (GTFS) to create statewide maps of transit speeds, why it matters, and how the project has evolved in response to stakeholder feedback.
+
 ### About Eric Dasmalchi
 
 Eric Dasmalchi is a Research Data Analyst at Caltrans in the Division of Data and Digital Services. Prior to Caltrans, Eric studied Urban and Regional Planning at UCLA and previously worked with transportation data at Jarvus Innovations and the UCLA Institute of Transportation Studies. He currently lives in Palms, Los Angeles and besides transit data he likes to tinker with electronics and sail small boats.

--- a/src/_posts/2023-11-14-data-donuts-39.md
+++ b/src/_posts/2023-11-14-data-donuts-39.md
@@ -2,8 +2,8 @@
 layout: post
 
 #event information
-title:  "REAP 2.0: A Transportation and Housing Cornucopia"
-date:   2023-11-14 08:00+0800
+title: "REAP 2.0: A Transportation and Housing Cornucopia"
+date: 2023-11-14 08:00
 start_time: "08:00am"
 end_time: "10:00am"
 
@@ -11,8 +11,8 @@ location: LACI
 cover: ../images/la-kretz-campus.jpeg
 
 #event speaker details
-speakers: 
- - "Nolan Borgman"
+speakers:
+  - "Nolan Borgman"
 eventbrite: "https://eventbrite.com/tickets-external?eid=744707569387&ref=etckt"
 slides: ""
 video: ""
@@ -21,6 +21,7 @@ video: ""
 ## SCAG’s $246 million effort to change transportation and housing paradigms.
 
 Nolan will outline SCAG’s plans to spend $246 million by the end of 2025 on transportation programs with a nexus to housing and vice versa. He will then highlight a $15 million program to develop and implement regionally significant pilots. He will go over everything from mobility hubs, mobility wallets/ubm, active transportation, and big data research projects during his presentation.
+
 ### About Nolan Borgman
 
 Nolan V. Borgman is a Planning Supervisor at the Southern California Association of Governments (SCAG) on the Partnerships for Innovative Deployment team. He manages a team of four responsible for delivering $100 million in REAP 2.0 funded transportation programs that prioritize affordable housing, sustainable transportation, and resilient infrastructure. Prior to joining SCAG, Nolan was a Manager in Metro’s Office of Strategic Innovation (OSI) where he led Metro’s Unsolicited Proposal (UP) Program, which helped shape a diverse portfolio of projects totaling over $10 billion. Through this program, Nolan oversaw the review of over 250 proposals and led resulting projects including the Zero Emission Bus Business Case & Delivery Strategy, Los Angeles Aerial Rapid Transit, and award-winning Camera Bus Lane Enforcement and Drone Data Collection programs. Before joining OSI, Nolan worked in the Audit Department and in the Office of the CEO staffing three different CEOs. He is a graduate of the Coro Fellows Program and Occidental College, where he studied Urban and Environmental Policy.

--- a/src/_posts/2024-02-29-data-donuts-40.md
+++ b/src/_posts/2024-02-29-data-donuts-40.md
@@ -2,8 +2,8 @@
 layout: post
 
 #event information
-title:  "An Open-Loop Payments Deployment - The Good. The Bad. And The Ugly."
-date:   2024-02-29 08:00+0800
+title: "An Open-Loop Payments Deployment - The Good. The Bad. And The Ugly."
+date: 2024-02-29 08:00
 start_time: "08:00am"
 end_time: "10:00am"
 
@@ -11,8 +11,8 @@ location: LACI
 cover: ../images/la-kretz-campus.jpeg
 
 #event speaker details
-speakers: 
- - "Michael Kohlman"
+speakers:
+  - "Michael Kohlman"
 eventbrite: "https://eventbrite.com/tickets-external?eid=817572109187&ref=etckt"
 slides: ""
 video: ""

--- a/src/_posts/2024-05-29-data-donuts-41.md
+++ b/src/_posts/2024-05-29-data-donuts-41.md
@@ -2,8 +2,8 @@
 layout: post
 
 #event information
-title:  "Got Data: Now What?"
-date:   2024-05-29 08:00+0800
+title: "Got Data: Now What?"
+date: 2024-05-29 08:00
 start_time: "08:00am"
 end_time: "10:00am"
 
@@ -11,8 +11,8 @@ location: LACI
 cover: ../images/la-kretz-campus.jpeg
 
 #event speaker details
-speakers: 
- - "Kate Holmquist"
+speakers:
+  - "Kate Holmquist"
 eventbrite: "https://eventbrite.com/tickets-external?eid=905723612707&ref=etckt"
 slides: ""
 video: ""

--- a/src/_posts/2024-06-27-data-donuts-42.md
+++ b/src/_posts/2024-06-27-data-donuts-42.md
@@ -2,8 +2,8 @@
 layout: post
 
 #event information
-title:  "Explaining On-Street Residential Parking"
-date:   2024-06-27 08:00+0800
+title: "Explaining On-Street Residential Parking"
+date: 2024-06-27 08:00
 start_time: "08:00am"
 end_time: "10:00am"
 
@@ -11,8 +11,8 @@ location: LACI
 cover: ../images/la-kretz-campus.jpeg
 
 #event speaker details
-speakers: 
- - "Raynell Cooper"
+speakers:
+  - "Raynell Cooper"
 eventbrite: "https://eventbrite.com/tickets-external?eid=905725729037&ref=etckt"
 slides: ""
 video: ""

--- a/src/_posts/2024-08-29-data-donuts-43.md
+++ b/src/_posts/2024-08-29-data-donuts-43.md
@@ -2,8 +2,8 @@
 layout: post
 
 #event information
-title:  "Digital Transformation"
-date:   2024-08-29 08:00+0800
+title: "Digital Transformation"
+date: 2024-08-29 08:00
 start_time: "08:00am"
 end_time: "10:00am"
 
@@ -11,8 +11,8 @@ location: LACI
 cover: ../images/la-kretz-campus.jpeg
 
 #event speaker details
-speakers: 
- - "Joe Nicchitta"
+speakers:
+  - "Joe Nicchitta"
 eventbrite: "https://eventbrite.com/tickets-external?eid=945235323297&ref=etckt"
 slides: ""
 video: ""

--- a/src/_posts/2024-09-26-data-donuts-44.md
+++ b/src/_posts/2024-09-26-data-donuts-44.md
@@ -2,8 +2,8 @@
 layout: post
 
 #event information
-title:  "Building a Data Science Community"
-date:   2024-09-26 08:00+0800
+title: "Building a Data Science Community"
+date: 2024-09-26 08:00
 start_time: "08:00am"
 end_time: "10:00am"
 
@@ -11,8 +11,8 @@ location: LACI
 cover: ../images/la-kretz-campus.jpeg
 
 #event speaker details
-speakers: 
- - "Robert Reny"
+speakers:
+  - "Robert Reny"
 eventbrite: "https://eventbrite.com/tickets-external?eid=989273031267&ref=etckt"
 slides: ""
 video: ""
@@ -25,4 +25,3 @@ As data science has become more widespread and accessible our team saw an opport
 ### About Robert Reny
 
 Robert is an Associate Resource Specialist within the Water Resources Management Group at the Metropolitan Water District of Southern California (MWD). At MWD Robert works on projects that involve spatial data including understanding crop water use and landscape area trends in Southern California. Related to this work, the team at MWD is also in the midst cultivating a data science community on the floor. He has a Bachelor’s of Science in Environmental Engineering from Northern Arizona University and a Master’s of Science from the University of California, Los Angeles (UCLA) in Environmental Health Science. He previously worked at the Los Angeles Regional Water Quality Control Board as a Water Resources Engineer but he left in 2020 to start an Environmental Science and Engineering Doctorate at UCLA.
-


### PR DESCRIPTION
Since the global Jekyll configuration sets the timezone to America/Los_Angeles, a timezone offset is no longer needed for each post.
