### PR TITLE
Add CODEOWNERS for PR review assignments

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+* @compilerla/engineering
+
+_data/ @compilerla/compiler-comms
+_posts/ @compilerla/compiler-comms


### PR DESCRIPTION
Copied from [compiler.la CODEOWNERS](https://github.com/compilerla/compiler.la/blob/main/.github/CODEOWNERS) file

Added `_data/` directory since that is currently used for event publishing.