### PR TITLE
Feat: Eleventy site metadata

### DIFF
--- a/src/_data/site.js
+++ b/src/_data/site.js
@@ -2,7 +2,6 @@ export default {
   title: "Data + Donuts LA",
   description: "Changing local government from the ground up.",
   email: "data-donuts@compiler.la",
-  event_label: "Events",
   github: "compilerla/data-donuts",
   timezone: "America/Los_Angeles",
   url: "https://datadonuts.la",

--- a/src/_data/site.js
+++ b/src/_data/site.js
@@ -1,0 +1,10 @@
+export default {
+  title: "Data + Donuts LA",
+  description: "Changing local government from the ground up.",
+  email: "data-donuts@compiler.la",
+  event_label: "Events",
+  github: "compilerla/data-donuts",
+  timezone: "America/Los_Angeles",
+  url: "https://datadonuts.la",
+  youtube: "UC_mAa07EdkkGCn48lq0yj3Q",
+};

--- a/src/_includes/footer.html
+++ b/src/_includes/footer.html
@@ -1,11 +1,13 @@
 <footer class="site-footer">
   <div class="wrapper">
     {% include "logos.html" %}
-    <br /><br />
+    <br/><br/>
     <p>
-      {{ site.title }} is produced by <a href="https://compiler.la/">Compiler</a>. Find us on
-      <a href="https://github.com/{{ site.github }}">GitHub</a> |
-      <a href="https://www.youtube.com/channel/UC_mAa07EdkkGCn48lq0yj3Q">YouTube</a>
+      {{ site.title }} is produced by
+      <a href="https://compiler.la/">Compiler</a>. Find us on
+      <a href="https://github.com/{{ site.github }}">GitHub</a>
+      |
+      <a href="https://www.youtube.com/channel/{{ site.youtube }}">YouTube</a>
     </p>
   </div>
 </footer>

--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -3,13 +3,26 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <title>{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}</title>
+  <title>
+    {% if page.title %}
+      {{ page.title | escape }}
+    {% else %}
+      {{ site.title | escape }}
+    {% endif %}
+  </title>
   <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
 
   <link href="https://fonts.googleapis.com/css?family=Raleway" rel="stylesheet">
 
-  <link rel="shortcut icon" type="image/x-icon" href="{{ "/favicon.ico" | prepend: site.baseurl }}" >
-  <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
-  <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
-  <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}">
+  <link
+    rel="shortcut icon"
+    type="image/x-icon"
+    href="/favicon.ico">
+  <link rel="stylesheet" href="/css/main.css">
+  <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.url }}">
+  <link
+    rel="alternate"
+    type="application/rss+xml"
+    title="{{ site.title }}"
+    href="{{ "/feed.xml" | prepend: site.url }}">
 </head>

--- a/src/_includes/header.html
+++ b/src/_includes/header.html
@@ -2,7 +2,7 @@
 
   <div class="wrapper">
 
-    <a class="site-title" href="{{ site.baseurl }}/">{{ site.title }}</a>
+    <a class="site-title" href="/">{{ site.title }}</a>
 
     <nav class="site-nav">
       <a href="#" class="menu-icon">
@@ -16,7 +16,7 @@
       <div class="trigger">
         {% for my_page in site.pages %}
           {% if my_page.navigation_title %}
-            <a class="page-link" href="{{ my_page.url | prepend: site.baseurl }}">{{ my_page.navigation_title }}</a>
+            <a class="page-link" href="{{ my_page.url }}">{{ my_page.navigation_title }}</a>
           {% endif %}
         {% endfor %}
       </div>

--- a/src/_includes/logos.html
+++ b/src/_includes/logos.html
@@ -1,5 +1,3 @@
 <div>
-  <img src="{{site.baseurl}}/images/compiler-logo-small.png" />&nbsp;&nbsp;&nbsp;<img
-    src="{{site.baseurl}}/images/laci-logo-small.png"
-  />
+  <img src="/images/compiler-logo-small.png" />&nbsp;&nbsp;&nbsp;<img src="/images/laci-logo-small.png" />
 </div>

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -9,8 +9,7 @@
 {% if page.cover %}
   <div class="blog-cover" style="background-image:url({{page.cover}});">
 {% else %}
-  <div class="blog-cover blog-cover-home" style="background-image:url({{site.baseurl}}/images/data-donuts-cover-logo.png
-);">
+  <div class="blog-cover blog-cover-home" style="background-image:url(/images/data-donuts-cover-logo.png);">
 {% endif %}
   </div>
   {% if page.cover_credit %}

--- a/src/about.md
+++ b/src/about.md
@@ -9,7 +9,7 @@ permalink: /about/
 
 <p>Our speakers and networking sessions will delve into the latest topics in technology: Big Data, Platform as a Service, DevOps, Open Data, Analytics and Visualization, Community Engagement, Civic Technology and more.</p>
 
-<img src="{{site.baseurl}}/images/digital-summit-award.jpg">
+<img src="/images/digital-summit-award.jpg">
 <caption><em>Data + Donuts organizers receiving 2018 Digital Government Summit Award</em></caption>
 
 <h1>Past Speakers</h1>

--- a/src/index.html
+++ b/src/index.html
@@ -22,7 +22,7 @@ layout: default
     <div class="clearfix">
 
 <!-- List Upcoming Events -->
-      <h1 class="event-time-heading fix-top">Upcoming {% if site.event_label %} {{site.event_label}} {% else %} Events {% endif %} </h1>
+      <h1 class="event-time-heading fix-top">Upcoming Events</h1>
 
       {% for post in site.posts reversed %}
 
@@ -52,7 +52,7 @@ layout: default
     <div class="clearfix">
 
 <!-- List Past Events -->
-      <h1 class="event-time-heading">Past {% if site.event_label %} {{site.event_label}} {% else %} Events {% endif %} </h1>
+      <h1 class="event-time-heading">Past Events</h1>
       {% for post in site.posts %}
 
         {% capture blogDate %}{{post.date | date: '%s' }}{% endcapture %}

--- a/src/index.html
+++ b/src/index.html
@@ -31,7 +31,7 @@ layout: default
 
         {% if blogDate >= currentDate %}
 
-          <a href="{{ post.url | prepend: site.baseurl }}">
+          <a href="{{ post.url }}">
           {% if location.image %}
             <div class="event-square" style="background-image:url({{location.image}});">
           {% elsif post.cover %}
@@ -59,7 +59,7 @@ layout: default
 
         {% if blogDate < currentDate %}
 
-          <a href="{{ post.url | prepend: site.baseurl }}">
+          <a href="{{ post.url }}">
              <div>
               <h2><span>{{ post.date | date: "%A, %b %-d, %Y" }}</span> w/
               {% assign n = post.speakers.size %}

--- a/src/speaker-info.md
+++ b/src/speaker-info.md
@@ -3,44 +3,50 @@ layout: page
 navigation_title: Speaker Info
 title: Info for Data + Donuts Speakers
 permalink: /speaker-info/
-
 ---
 
 Hello! Thank you for speaking at Data + Donuts. We are so excited to have you! Data + Donuts is a morning speaker series and networking event that brings together the makers and doers that are changing local government from the ground up by harnessing technology and data to drive meaningful change. Thank you for doing that! Here’s some important info to know for your presentation.
 
 Who are our speakers?
-+ Data + Donut’s speakers come from local Los Angeles and Southern California government agencies.
-+ Our speakers and networking sessions will delve into the latest topics in technology: Big Data, Platform as a Service, DevOps, Open Data, Analytics and Visualization, Community Engagement, Civic Technology and more.
+
+- Data + Donut’s speakers come from local Los Angeles and Southern California government agencies.
+- Our speakers and networking sessions will delve into the latest topics in technology: Big Data, Platform as a Service, DevOps, Open Data, Analytics and Visualization, Community Engagement, Civic Technology and more.
 
 What is the agenda?
-+ 8am - Doors Open/Networking
-+ 9am - Speaker Presentation
-+ 9:20am - Additional Networking
-+ 10am - Doors Close
+
+- 8am - Doors Open/Networking
+- 9am - Speaker Presentation
+- 9:20am - Additional Networking
+- 10am - Doors Close
 
 What are the presentation logistics?
-+ Presentations are 20 minutes, followed by up to 20 minutes of audience Q&A.
-+ Presentation must include a slide that shows your tech stack -- a list of all the technology services used to build and run one single application.
+
+- Presentations are 20 minutes, followed by up to 20 minutes of audience Q&A.
+- Presentation must include a slide that shows your tech stack -- a list of all the technology services used to build and run one single application.
 
 What to bring?
-+ You may bring your own laptop for the presentation.
-+ Our A/V set up has an HDMI connector, please bring an appropriate adapter or let us know if you need one.
-If you can’t bring a laptop, please notify us and we will supply one for your presentation.
+
+- You may bring your own laptop for the presentation.
+- Our A/V set up has an HDMI connector, please bring an appropriate adapter or let us know if you need one.
+  If you can’t bring a laptop, please notify us and we will supply one for your presentation.
 
 Who is the audience?
-+ 40-60 attendees.
-+ In terms of make up, our audience is around 80 percent local government employees and 20 percent local non-profits, students and the general public.
-+ Audiences are moderately technical.
+
+- 40-60 attendees.
+- In terms of make up, our audience is around 80 percent local government employees and 20 percent local non-profits, students and the general public.
+- Audiences are moderately technical.
 
 Where is the event located? Is parking available?
-+ Event is located at the LA Cleantech Incubator at the La Kretz Innovation Campus - 525 S Hewitt St Los Angeles, CA 90013
-+ Parking is available in the gated lot for a subsidised $6. We do not offer validation or reimbursement for speakers or attendees. The lot is stacked, so please prepare extra time when leaving the event. Street parking is also available.
-+ Bicycle parking is located in the front of the building.
-+ Metro Bike share available at 1210 E 5th St, Los Angeles, CA 90013
-+ The venue is about a mile from Pershing Square, Little Tokyo, and Union Station Metro stops with a variety of bus options, including the LADOT A Dash bus.
+
+- Event is located at the LA Cleantech Incubator at the La Kretz Innovation Campus - 525 S Hewitt St Los Angeles, CA 90013
+- Parking is available in the gated lot for a subsidised $6. We do not offer validation or reimbursement for speakers or attendees. The lot is stacked, so please prepare extra time when leaving the event. Street parking is also available.
+- Bicycle parking is located in the front of the building.
+- Metro Bike share available at 1210 E 5th St, Los Angeles, CA 90013
+- The venue is about a mile from Pershing Square, Little Tokyo, and Union Station Metro stops with a variety of bus options, including the LADOT A Dash bus.
 
 Is the building ADA Accessible?
-+ Yes. The presentation area has a podium, if a table or chair is needed for your laptop please notify us.
 
-<img src="{{site.baseurl}}/images/laci-speaker-venue.JPG">
+- Yes. The presentation area has a podium, if a table or chair is needed for your laptop please notify us.
+
+<img src="/images/laci-speaker-venue.JPG">
 <caption><em>Small amphitheater in the middle of building, podium with laptop, A/V setup</em></caption>


### PR DESCRIPTION
Closes #201 

Small PR that ports (most) values from Jekyll's `_config.yml` to a global Eleventy data file at `src/_data/site.js`.

Removes usage of `site.baseurl` throughout pages/templates as well.

## Review

Compare:

- `11ty` branch deploy: https://11ty--data-donuts.netlify.app/
- This PR's branch deploy: https://deploy-preview-202--data-donuts.netlify.app/

Note that the site title / link at the top (`Data + Donuts LA`), and GitHub link in the footer, are both present in this PR's preview but not the `11ty` branch.