### PR TITLE
Feat: define Eleventy collection for pages

### DIFF
--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -10,7 +10,7 @@
       {{ site.title | escape }}
     {% endif %}
   </title>
-  <meta name="description" content="{{ site.description }}">
+  <meta name="description" content="{% if excerpt %}{{ excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
 
   <link href="https://fonts.googleapis.com/css?family=Raleway" rel="stylesheet">
 

--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -4,8 +4,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
   <title>
-    {% if page.title %}
-      {{ page.title | escape }}
+    {% if title %}
+      {{ title | escape }}
     {% else %}
       {{ site.title | escape }}
     {% endif %}

--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -10,7 +10,7 @@
       {{ site.title | escape }}
     {% endif %}
   </title>
-  <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
+  <meta name="description" content="{{ site.description }}">
 
   <link href="https://fonts.googleapis.com/css?family=Raleway" rel="stylesheet">
 

--- a/src/_includes/header.html
+++ b/src/_includes/header.html
@@ -14,9 +14,9 @@
       </a>
 
       <div class="trigger">
-        {% for my_page in site.pages %}
-          {% if my_page.navigation_title %}
-            <a class="page-link" href="{{ my_page.url }}">{{ my_page.navigation_title }}</a>
+        {% for my_page in collections.page %}
+          {% if my_page.data.navigation_title %}
+            <a class="page-link" href="{{ my_page.url }}">{{ my_page.data.navigation_title }}</a>
           {% endif %}
         {% endfor %}
       </div>

--- a/src/_includes/header.html
+++ b/src/_includes/header.html
@@ -14,11 +14,8 @@
       </a>
 
       <div class="trigger">
-        {% for my_page in collections.pages %}
-          {% if my_page.data.navigation_title %}
-            <a class="page-link" href="{{ my_page.url }}">{{ my_page.data.navigation_title }}</a>
-          {% endif %}
-        {% endfor %}
+        <a class="page-link" href="/about/">About</a>
+        <a class="page-link" href="/speaker-info/">Speaker Info</a>
       </div>
     </nav>
 

--- a/src/_includes/header.html
+++ b/src/_includes/header.html
@@ -14,7 +14,7 @@
       </a>
 
       <div class="trigger">
-        {% for my_page in collections.page %}
+        {% for my_page in collections.pages %}
           {% if my_page.data.navigation_title %}
             <a class="page-link" href="{{ my_page.url }}">{{ my_page.data.navigation_title }}</a>
           {% endif %}

--- a/src/_layouts/page.html
+++ b/src/_layouts/page.html
@@ -4,7 +4,7 @@ layout: default
 <article class="post">
 
   <header class="post-header">
-    <h1 class="post-title">{{ page.title }}</h1>
+    <h1 class="post-title">{{ title }}</h1>
   </header>
 
   <div class="post-content">

--- a/src/about.md
+++ b/src/about.md
@@ -1,5 +1,4 @@
 ---
-navigation_title: About
 title: About Data + Donuts
 permalink: /about/
 ---

--- a/src/about.md
+++ b/src/about.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 navigation_title: About
 title: About Data + Donuts
 permalink: /about/

--- a/src/about.md
+++ b/src/about.md
@@ -11,7 +11,7 @@ permalink: /about/
 <img src="/images/digital-summit-award.jpg">
 <caption><em>Data + Donuts organizers receiving 2018 Digital Government Summit Award</em></caption>
 
-<h1>Past Speakers</h1>
+<h2>Past Speakers</h2>
 <ul>
 {% for speaker in site.data.speakers %}
   <li>

--- a/src/index.html
+++ b/src/index.html
@@ -1,6 +1,5 @@
 ---
 layout: default
-
 ---
 
 <div class="home">

--- a/src/index.html
+++ b/src/index.html
@@ -21,7 +21,7 @@ layout: default
     <div class="clearfix">
 
 <!-- List Upcoming Events -->
-      <h1 class="event-time-heading fix-top">Upcoming Events</h1>
+      <h2 class="event-time-heading fix-top">Upcoming Events</h2>
 
       {% for post in site.posts reversed %}
 
@@ -38,7 +38,7 @@ layout: default
           {% else %}
             <div class="event-square" style="background-image:url(http://evento.io/img/cover.jpg);">
           {% endif %}
-              <h2>{{ post.title }} <span>{{ post.date | date: "%A, %b %-d, %Y" }}</span></h2>
+              <h3>{{ post.title }} <span>{{ post.date | date: "%A, %b %-d, %Y" }}</span></h3>
                <div class='event-square-overlay'></div>
             </div>
 
@@ -51,7 +51,7 @@ layout: default
     <div class="clearfix">
 
 <!-- List Past Events -->
-      <h1 class="event-time-heading">Past Events</h1>
+      <h2 class="event-time-heading">Past Events</h2>
       {% for post in site.posts %}
 
         {% capture blogDate %}{{post.date | date: '%s' }}{% endcapture %}
@@ -60,12 +60,12 @@ layout: default
 
           <a href="{{ post.url }}">
              <div>
-              <h2><span>{{ post.date | date: "%A, %b %-d, %Y" }}</span> w/
+              <h3><span>{{ post.date | date: "%A, %b %-d, %Y" }}</span> w/
               {% assign n = post.speakers.size %}
               {% assign n-commas = n | minus: 1 %}
               {% for counter in (0..n) %}
                 {{ post.speakers[counter] }}{% if counter < n-commas %}, {% endif %}
-              {% endfor %}</h2>
+              {% endfor %}</h3>
              </div>
           </a>
 

--- a/src/speaker-info.md
+++ b/src/speaker-info.md
@@ -1,5 +1,4 @@
 ---
-navigation_title: Speaker Info
 title: Info for Data + Donuts Speakers
 permalink: /speaker-info/
 ---

--- a/src/speaker-info.md
+++ b/src/speaker-info.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 navigation_title: Speaker Info
 title: Info for Data + Donuts Speakers
 permalink: /speaker-info/

--- a/src/src.11tydata.js
+++ b/src/src.11tydata.js
@@ -1,0 +1,3 @@
+export default {
+  layout: "page.html",
+};

--- a/src/src.11tydata.js
+++ b/src/src.11tydata.js
@@ -1,3 +1,4 @@
 export default {
+  tags: "page",
   layout: "page.html",
 };

--- a/src/src.11tydata.js
+++ b/src/src.11tydata.js
@@ -1,4 +1,4 @@
 export default {
-  tags: "page",
+  tags: "pages",
   layout: "page.html",
 };

--- a/src/src.11tydata.js
+++ b/src/src.11tydata.js
@@ -1,4 +1,4 @@
 export default {
   tags: "pages",
-  layout: "page.html",
+  layout: "page",
 };


### PR DESCRIPTION
Closes #206 

- Defines a `pages` collection via a directory data file `src/src.11tydata.js` with layout defaults. 

- ~Uses the `pages` collection to render the nav, similar to the prior loop over Jekyll's `site.pages`~
  - ~this might be overkill (for 2 pages!!) but it was the most similar port of existing Jekyll functionality, plus I wanted to figure out some 11ty collections semantics before getting into #204~
  - This _was_ overkill, and introduced a problem where the nav could reorder as pages were updated. Went back to a simpler, hardcoded approach.

## Review

Compare:

- `11ty` branch deploy: https://11ty--data-donuts.netlify.app/
- This PR's branch deploy: https://deploy-preview-208--data-donuts.netlify.app/

Note that the nav links (`About`, `Speaker Info`), `<title>` elements, and page title `<h1>`, are all present and working as expected in this PR's preview but not the `11ty` branch.