### PR TITLE
fix: remove RSS feed link from head.html

### DIFF
--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -20,9 +20,4 @@
     href="/favicon.ico">
   <link rel="stylesheet" href="/css/main.css">
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.url }}">
-  <link
-    rel="alternate"
-    type="application/rss+xml"
-    title="{{ site.title }}"
-    href="{{ "/feed.xml" | prepend: site.url }}">
 </head>


### PR DESCRIPTION
since we don't actually generate an RSS feed, lets stop advertising it.

https://datadonuts.la/feed.xml